### PR TITLE
[#95] Fix serial reconnect

### DIFF
--- a/docs/UI_test.md
+++ b/docs/UI_test.md
@@ -1,0 +1,15 @@
+# Serial Console test
+
+- Serial communication, hardware level
+    - [ ] connect to device
+    - [ ] get data from mcu
+    - [ ] send data to mcu
+    - [ ] switch connect to the same/another device
+    - [ ] show disconnect info when unplug
+    - [ ] reconnect after unplug then replug
+- tweaks
+    - [ ] auto send ctrl-c then ctrl-d on connect, to restart the script.
+- UI
+    - [ ] terminal size react to tab size
+- Config
+    - [ ] terminal font size react to settings

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,10 @@
+# Unify code wording
+
+## Serial
+- avoid using serial in, out, received, send, instead, use
+    - IDE code
+        - fromMcu (MCU: microcontroller unit)
+        - toMcu
+    - CPY library code 
+        - fromIde
+        - toIde

--- a/package-lock.json
+++ b/package-lock.json
@@ -4575,9 +4575,9 @@
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,7 +47,6 @@ function App() {
         serialOutput,
         fullSerialHistory,
         serialReady,
-        serialTitle,
     } = useSerial();
     // config
     const { config, set_config, ready: configReady } = useConfig(schemas);
@@ -138,7 +137,6 @@ function App() {
                 serialOutput: serialOutput,
                 fullSerialHistory: fullSerialHistory,
                 serialReady: serialReady,
-                serialTitle: serialTitle,
                 schemas: schemas,
                 config: config,
                 set_config: set_config,

--- a/src/serial/serial.js
+++ b/src/serial/serial.js
@@ -1,0 +1,110 @@
+export default class SerialCommunication {
+    constructor() {
+        this.port = null;
+        this.reader = null;
+        this.writer = null;
+        this.keepRunning = true;
+        this.writeBuffer = [];
+        this.readerCallbacks = {};
+    }
+
+    async open(portOptions) {
+        if ('serial' in navigator) {
+            try {
+                this.port = await navigator.serial.requestPort(portOptions);
+            } catch (error) {
+                console.error('Error requesting serial port:', error);
+                return false;
+            }
+            try {
+                await this.port.open({ baudRate: 115200 });
+
+                this.reader = this.port.readable.getReader();
+                this.writer = this.port.writable.getWriter();
+
+                this.readLoop();
+                this.writeLoop();
+                return true;
+            } catch (error) {
+                console.error('Error opening serial port:', error);
+            }
+        } else {
+            console.error('Web Serial API not supported.');
+        }
+        return false;
+    }
+
+    async close() {
+        this.keepRunning = false;
+
+        if (this.reader) {
+            await this.reader.cancel();
+            await this.reader.releaseLock();
+            this.reader = null;
+        }
+
+        if (this.writer) {
+            await this.writer.releaseLock();
+            this.writer = null;
+        }
+
+        if (this.port) {
+            await this.port.close();
+            this.port = null;
+        }
+    }
+
+    registerReaderCallback(id, callback) {
+        this.readerCallbacks[id] = callback;
+    }
+
+    unregisterReaderCallback(id) {
+        delete this.readerCallbacks[id];
+    }
+
+    write(data) {
+        this.writeBuffer.push(data);
+    }
+
+    async readLoop() {
+        this.keepRunning = true;
+        const decoder = new TextDecoder();
+        while (this.port.readable && this.keepRunning) {
+            try {
+                const { value, done } = await this.reader.read();
+                if (done || !this.keepRunning) {
+                    break;
+                }
+                const decoded = decoder.decode(value);
+                for (const id in this.readerCallbacks) {
+                    this.readerCallbacks[id](decoded);
+                }
+            } catch (error) {
+                console.error('Error reading from serial port:', error);
+            }
+        }
+    }
+
+    async writeLoop() {
+        const encoder = new TextEncoder();
+        while (this.port.writable && this.keepRunning) {
+            if (this.writeBuffer.length > 0) {
+                // const data = this.writeBuffer.join('');
+
+                while (this.writeBuffer.length > 0) {
+                    const data = this.writeBuffer.shift();
+
+                    try {
+                        await this.writer.write(encoder.encode(data));
+                    } catch (error) {
+                        console.error('Error writing to serial port:', error);
+                        this.keepRunning = false;
+                    }
+                }
+
+                this.writeBuffer = [];
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1)); // Small delay to prevent high CPU usage
+        }
+    }
+}

--- a/src/serial/serial.js
+++ b/src/serial/serial.js
@@ -40,6 +40,7 @@ export default class SerialCommunication {
     async close() {
         console.log("trying to close serial communication");
         this.keepRunning = false;
+        this.writeBuffer = [];
 
         if (this.reader) {
             try {

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -55,7 +55,7 @@ const useSerial = () => {
                 console.log("trying to restart MCU program");
                 // break any current run (no effect/harm in repl)
                 await sendDataToSerialPort(constants.CTRL_C);
-                sleep(200);
+                sleep(2000);// TODO: this is not working sometimes, even if the next line is ran, still not started.
                 // start a fresh run (No matter from REPL or code)
                 await sendDataToSerialPort(constants.CTRL_D);
             } else {

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import * as constants from "../constants";
 import SerialCommunication from "./serial";
+import { sleep } from "./utils";
 
 const serial = new SerialCommunication();
 
@@ -54,6 +55,7 @@ const useSerial = () => {
                 console.log("trying to restart MCU program");
                 // break any current run (no effect/harm in repl)
                 await sendDataToSerialPort(constants.CTRL_C);
+                sleep(200);
                 // start a fresh run (No matter from REPL or code)
                 await sendDataToSerialPort(constants.CTRL_D);
             } else {

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import * as constants from "../constants";
-import { matchesInBetween } from "./textProcessor";
 import SerialCommunication from "./serial";
 
 const serial = new SerialCommunication();
@@ -9,7 +8,6 @@ const useSerial = () => {
     const [serialReady, setSerialReady] = useState(false);
     const [fullSerialHistory, setFullSerialHistory] = useState("");
     const [serialOutput, setSerialOutput] = useState("");
-    const [serialTitle, setSerialTitle] = useState("");
 
     useEffect(() => {
         if (!navigator.serial) {
@@ -21,18 +19,14 @@ const useSerial = () => {
         });
     }, []);
 
-    useEffect(() => {
-        setSerialTitle(matchesInBetween(serialOutput, constants.TITLE_START, constants.TITLE_END).at(-1));
-    }, [serialOutput]);
-
     const connectToSerialPort = async () => {
-        if (serialReady) {
-            if (confirm("Do you want to connect to a new device?")) {
+            if (serialReady) {
+                if (confirm("Do you want to connect to a new device?")) {
                 await disconnectFromSerialPort();
-            } else {
-                return;
+                } else {
+                    return;
+                }
             }
-        }
         try {
             const status = await serial.open();
             setSerialReady(status);
@@ -68,6 +62,7 @@ const useSerial = () => {
         }
 
         serial.write(data);
+        console.log("sent data to mcu:", [data]);
     };
 
     function clearSerialOutput() {
@@ -85,7 +80,6 @@ const useSerial = () => {
         serialOutput,
         fullSerialHistory,
         serialReady,
-        serialTitle,
     };
 };
 

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -20,18 +20,19 @@ const useSerial = () => {
     }, []);
 
     const connectToSerialPort = async () => {
-            if (serialReady) {
-                if (confirm("Do you want to connect to a new device?")) {
+        if (serialReady) {
+            if (confirm("Do you want to connect to a new device?")) {
                 await disconnectFromSerialPort();
-                } else {
-                    return;
-                }
+            } else {
+                return;
             }
+        }
         try {
             const status = await serial.open();
             setSerialReady(status);
             if (status) {
                 /* cleanup history */
+                console.log("cleanup from MCU serial history");
                 setFullSerialHistory("");
                 setSerialOutput("");
                 /** restart the script on mcu, with benefits:
@@ -39,6 +40,7 @@ const useSerial = () => {
                  * * Behavior of CPY each time when IDE starts are consistent
                  * Please ignore whatever is before the first `soft reboot` text
                  */
+                console.log("trying to restart MCU program");
                 // break any current run (no effect/harm in repl)
                 await sendDataToSerialPort(constants.CTRL_C);
                 // start a fresh run (No matter from REPL or code)
@@ -57,12 +59,12 @@ const useSerial = () => {
     };
 
     const sendDataToSerialPort = async (data) => {
-        if (!serialReady) {
-            return;
+        try {
+            serial.write(data);
+            console.log("sent data to mcu:", [data]);
+        } catch (err) {
+            console.error("Failed to send data to MCU:", err);
         }
-
-        serial.write(data);
-        console.log("sent data to mcu:", [data]);
     };
 
     function clearSerialOutput() {

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -55,7 +55,7 @@ const useSerial = () => {
                 console.log("trying to restart MCU program");
                 // break any current run (no effect/harm in repl)
                 await sendDataToSerialPort(constants.CTRL_C);
-                sleep(2000);// TODO: this is not working sometimes, even if the next line is ran, still not started.
+                await sleep(500);
                 // start a fresh run (No matter from REPL or code)
                 await sendDataToSerialPort(constants.CTRL_D);
             } else {

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -1,58 +1,25 @@
 import { useState, useEffect } from "react";
 import * as constants from "../constants";
 import { matchesInBetween } from "./textProcessor";
+import SerialCommunication from "./serial";
+
+const serial = new SerialCommunication();
 
 const useSerial = () => {
-    const [port, setPort] = useState(null);
+    const [serialReady, setSerialReady] = useState(false);
     const [fullSerialHistory, setFullSerialHistory] = useState("");
     const [serialOutput, setSerialOutput] = useState("");
     const [serialTitle, setSerialTitle] = useState("");
-    const [serialReady, setSerialReady] = useState(false);
 
     useEffect(() => {
         if (!navigator.serial) {
             console.warn("Web Serial API not supported");
         }
+
+        serial.registerReaderCallback("dataFromMcu", (data) => {
+            setSerialOutput((previousOutput) => previousOutput + data);
+        });
     }, []);
-
-    useEffect(() => {
-        let reader;
-        let active = true;
-
-        const readData = async () => {
-            while (port && port.readable && active) {
-                try {
-                    reader = port.readable.getReader();
-                    while (true) {
-                        const { value, done } = await reader.read();
-                        if (done) {
-                            reader.releaseLock();
-                            break;
-                        }
-                        setSerialOutput((previousOutput) => previousOutput + new TextDecoder().decode(value));
-                    }
-                } catch (err) {
-                    setPort(null);
-                    setSerialReady(false);
-                    setSerialOutput("");
-                    setSerialTitle("");
-                    console.error("Failed to read data:", err);
-                } finally {
-                    reader && reader.releaseLock();
-                }
-            }
-        };
-
-        readData();
-
-        return () => {
-            const close = async () => {
-                active = false;
-                reader && (await reader.releaseLock());
-            };
-            close();
-        };
-    }, [port]);
 
     useEffect(() => {
         setSerialTitle(matchesInBetween(serialOutput, constants.TITLE_START, constants.TITLE_END).at(-1));
@@ -60,63 +27,37 @@ const useSerial = () => {
 
     const connectToSerialPort = async () => {
         try {
-            const newPort = await navigator.serial.requestPort();
-            await newPort.open({ baudRate: 115200 });
-            setPort(newPort);
-            setSerialReady(true);
+            const status = await serial.open();
+            setSerialReady(status);
+            if (status) {
+                /**
+                 * This effect has two benefits
+                 * * There will not be any "half blocks" when staring the IDE
+                 * * Behavior of CPY each time when IDE starts are consistent
+                 * Please ignore whatever is before the first `soft reboot` text
+                 */
+                // break any current run (no effect/harm in repl)
+                await sendDataToSerialPort(constants.CTRL_C);
+                // start a fresh run (No matter from REPL or code)
+                await sendDataToSerialPort(constants.CTRL_D);
+            } else {
+                serial.close();
+            }
         } catch (err) {
             console.error("Failed to connect:", err);
         }
     };
 
-    const sendDataToSerialPort = async (data) => {
-        if (!port || !port.writable) return;
-
-        const writer = port.writable.getWriter();
-        const encodedData = new TextEncoder().encode(data);
-
-        try {
-            await writer.write(encodedData);
-        } catch (err) {
-            console.error("Failed to send data:", err);
-        } finally {
-            writer.releaseLock();
-        }
+    const disconnectFromSerialPort = async function () {
+        await serial.close();
     };
 
-    useEffect(() => {
-        /**
-         * This effect has two benefits
-         * * There will not be any "half blocks" when staring the IDE
-         * * Behavior of CPY each time when IDE starts are consistent
-         * Please ignore whatever is before the first `soft reboot` text
-         */
-        async function clean_start() {
-            if (serialReady) {
-                // break any current run (no effect/harm in repl)
-                await sendDataToSerialPort(constants.CTRL_C);
-                // start a fresh run (No matter from REPL or code)
-                await sendDataToSerialPort(constants.CTRL_D);
-            }
-        }
-        clean_start();
-    }, [serialReady]);
-
-    const disconnect = async () => {
-        // not working yet
-        if (!port) return;
-
-        const reader = port.readable.getReader();
-        // Close the input stream (reader).
-        if (reader) {
-            await reader.cancel();
+    const sendDataToSerialPort = async (data) => {
+        if (!serialReady) {
+            return;
         }
 
-        await port.close();
-        setPort(null);
-        setSerialReady(false);
-        setSerialOutput("");
-        setSerialTitle("");
+        serial.write(data);
     };
 
     function clearSerialOutput() {
@@ -128,6 +69,7 @@ const useSerial = () => {
 
     return {
         connectToSerialPort,
+        disconnectFromSerialPort,
         sendDataToSerialPort,
         clearSerialOutput,
         serialOutput,
@@ -138,3 +80,11 @@ const useSerial = () => {
 };
 
 export default useSerial;
+
+/**
+ * TODO
+ * move Title to console, this is not the place
+ * change name according to docs/terms.md
+ * add callback to returns
+ * change the code structure, serial and use Serial to a folder, serial console to a folder.
+ */

--- a/src/serial/useSerial.js
+++ b/src/serial/useSerial.js
@@ -10,13 +10,24 @@ const useSerial = () => {
     const [serialOutput, setSerialOutput] = useState("");
 
     useEffect(() => {
+        // check if browser compatible
         if (!navigator.serial) {
             console.error("Web Serial API not supported");
         }
 
+        // setup callback to get full history
         serial.registerReaderCallback("dataFromMcu", (data) => {
             setSerialOutput((previousOutput) => previousOutput + data);
         });
+    }, []);
+    // check if port closed unexpected
+    useEffect(() => {
+        const interval = setInterval(() => {
+            if (serial.port === null) {
+                setSerialReady(false);
+            }
+        }, 1000);
+        return () => clearInterval(interval);
     }, []);
 
     const connectToSerialPort = async () => {

--- a/src/serial/useSerialCommands.js
+++ b/src/serial/useSerialCommands.js
@@ -13,7 +13,6 @@ export default function useSerialCommands() {
     function addCodeHistory(code) {
         setCodeHistory((curCodeHistory) => {
             const newHistory = [...curCodeHistory.filter((historyCode) => historyCode != code), code];
-            console.log(newHistory);
             return newHistory;
         });
     }

--- a/src/serial/utils.js
+++ b/src/serial/utils.js
@@ -17,3 +17,6 @@ export function removeCommonIndentation(text) {
     // Remove the common indentation from each non-empty line and join them back into a single string.
     return lines.map((line) => line.substring(commonIndent)).join("\n");
 }
+
+// https://sentry.io/answers/what-is-the-javascript-version-of-sleep/
+export const sleep = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/tabs/RawConsole.jsx
+++ b/src/tabs/RawConsole.jsx
@@ -23,6 +23,8 @@ import Toolbar from "@mui/material/Toolbar";
 import { Menu } from "../layout/Menu";
 // download log
 import { downloadAsFile } from "../react-local-file-system";
+// textProcessor
+import { matchesInBetween } from "../serial/textProcessor";
 
 const RawSerialIn = () => {
     // "in" to computer, "out" from microcontroller
@@ -188,11 +190,15 @@ const RawSerialOut = ({
 
 const RawConsole = () => {
     const { sendCtrlC, sendCtrlD, sendCode, codeHistory } = useSerialCommands();
-    const { fullSerialHistory, serialTitle, serialOutput, clearSerialOutput } = useContext(ideContext);
-    // Serial Out states
-    const { serialReady: ready, connectToSerialPort: connect } = useContext(ideContext);
+    const { fullSerialHistory, serialOutput, clearSerialOutput, serialReady, connectToSerialPort } =
+        useContext(ideContext);
+    const [serialTitle, setSerialTitle] = useState("");
     const [text, setText] = useState("");
     const [codeHistIndex, setCodeHistIndex] = useState(-1);
+
+    useEffect(() => {
+        setSerialTitle(matchesInBetween(serialOutput, constants.TITLE_START, constants.TITLE_END).at(-1));
+    }, [serialOutput]);
 
     function consoleSendCommand() {
         if (text.trim().length === 0) {
@@ -219,7 +225,7 @@ const RawConsole = () => {
         },
     ];
 
-    return ready ? (
+    return serialReady ? (
         <div style={{ display: "flex", flexDirection: "column", height: "100%", overflowX: "hidden" }}>
             <div
                 style={{
@@ -308,7 +314,7 @@ const RawConsole = () => {
             </div>
         </div>
     ) : (
-        <Button onClick={connect}>Connect to Serial Port</Button>
+        <Button onClick={connectToSerialPort}>Connect to Serial Port</Button>
     );
 };
 

--- a/src/tabs/RawConsole.jsx
+++ b/src/tabs/RawConsole.jsx
@@ -71,7 +71,6 @@ const RawSerialOut = ({
             if (newCodeHistoryIndex < 0) {
                 newCodeHistoryIndex = 0;
             }
-            console.log(codeHistIndex, codeHistory[codeHistIndex]);
             aceEditorRef.current.editor.session.setValue(codeHistory[newCodeHistoryIndex]);
             aceEditorRef.current.editor.gotoLine(0, 0, true);
         } else {


### PR DESCRIPTION
using a class to handle the serial connection and leave handle for xterm to connect in the future

MISC
- moved serial title handling to serial console component
- added sleep in between the ctrl-c and ctrl-d on connect to increase stability. 
- added term guidance and test guidance in docs

## Testing

as this is affecting the serial connection the following tests are performed:
- Serial communication, hardware level
    - [x] connect to device
    - [x] get data from mcu
    - [x] send data to mcu
    - [x] switch connect to the same/another device
    - [x] show disconnect info when unplug
    - [x] reconnect after unplug then replug
- tweaks
    - [x] auto send ctrl-c then ctrl-d on connect, to restart the script.
    