### PR TITLE
changed editor tab opening order

### DIFF
--- a/docs/UI_test.md
+++ b/docs/UI_test.md
@@ -10,6 +10,12 @@
 - tweaks
     - [ ] auto send ctrl-c then ctrl-d on connect, to restart the script.
 - UI
+    - serial console
+    - flex layout
+        - opening Editor tab order
+            - [ ] when there is "initial_tabset", always open editor tab to "initial_tabset"
+            - [ ] else when there is active tab, open editor in active tab
+            - [ ] else open in the first tabset. 
     - [ ] terminal size react to tab size
 - Config
     - [ ] terminal font size react to settings

--- a/src/IdeBody.jsx
+++ b/src/IdeBody.jsx
@@ -35,6 +35,18 @@ const findTabByName = (node, name) => {
     return null;
 };
 
+const findTabsetById = (model, tabsetId) => {
+    let foundTabset = null; // Default to null if not found
+
+    model.visitNodes((node) => {
+        if (node.getType() === "tabset" && node.getId() === tabsetId) {
+            foundTabset = node;
+        }
+    });
+
+    return foundTabset;
+};
+
 export default function IdeBody() {
     const { flexModel: model, schemas, config, set_config } = useContext(ideContext);
     const [fileLookUp, setFileLookUp] = useState({});
@@ -71,7 +83,9 @@ export default function IdeBody() {
                         },
                     },
 
-                    model.getActiveTabset()
+                    findTabsetById(model, "initial_tabset")
+                        ? "initial_tabset"
+                        : model.getActiveTabset()
                         ? model.getActiveTabset().getId()
                         : model.getRoot().getChildren()[0].getId(), // there should be at least one tabset
                     FlexLayout.DockLocation.CENTER,

--- a/src/layout/layout.json
+++ b/src/layout/layout.json
@@ -47,6 +47,7 @@
                 "type": "tabset",
                 "weight": 50,
                 "selected": 0,
+                "id": "initial_tabset",
                 "children": [
                     {
                         "type": "tab",

--- a/src/serial/useSerialCommands.js
+++ b/src/serial/useSerialCommands.js
@@ -3,9 +3,6 @@ import ideContext from "../ideContext";
 import * as constants from "../constants";
 import { removeCommonIndentation, sleep } from "./utils";
 
-// https://sentry.io/answers/what-is-the-javascript-version-of-sleep/
-const sleep = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
-
 export default function useSerialCommands() {
     const { config, sendDataToSerialPort: send, serialOutput: output, serialReady: ready } = useContext(ideContext);
     const [codeHistory, setCodeHistory] = useState(['print("Hello CircuitPython!")']);


### PR DESCRIPTION
Always open Editor tab in the initial tab set when it exists could help not mess up the serial console tab.

- misc: fix sleep redefined

tested
- opening Editor tab order
    - [x] when there is "initial_tabset", always open editor tab to "initial_tabset"
    - [x] else when there is active tab, open editor in active tab
    - [x] else open in the first tabset. 