### PR TITLE
[#104] fix text pile up

### DIFF
--- a/docs/UI_test.md
+++ b/docs/UI_test.md
@@ -1,5 +1,18 @@
-# Serial Console test
+# Manual test
+Here is the list of manual test steps and expected behaviors.
+This list grows as test steps are recorded when creating PRs.
 
+## Flex Layout
+- opening Editor tab order
+    - [ ] when there is "initial_tabset", always open editor tab to "initial_tabset"
+    - [ ] else when there is active tab, open editor in active tab
+    - [ ] else open in the first tabset.
+
+## Folder View
+- content list
+    - [ ] When a file name is very long and contains multiple words connected with ` ` or `-`, the file name can be wrapped to multiple line, and the height of the item is adapting to the height of text.
+
+## Serial Console
 - Serial communication, hardware level
     - [ ] connect to device
     - [ ] get data from mcu
@@ -10,12 +23,6 @@
 - tweaks
     - [ ] auto send ctrl-c then ctrl-d on connect, to restart the script.
 - UI
-    - serial console
-    - flex layout
-        - opening Editor tab order
-            - [ ] when there is "initial_tabset", always open editor tab to "initial_tabset"
-            - [ ] else when there is active tab, open editor in active tab
-            - [ ] else open in the first tabset. 
     - [ ] terminal size react to tab size
 - Config
     - [ ] terminal font size react to settings

--- a/src/react-local-file-system/components/ContentEntry.jsx
+++ b/src/react-local-file-system/components/ContentEntry.jsx
@@ -21,8 +21,7 @@ export default function ContentEntry({ entryHandle }) {
     const entryName = entryHandle.isParent ? ".." : entryHandle.name;
     const isDraggable = !entryHandle.isParent;
 
-    const itemSize = 30;
-    const iconSize = itemSize - 10;
+    const iconSize = 20;
 
     const iconSx = { width: `${iconSize}px`, height: `${iconSize}px` };
     let icon = <FileIcon sx={iconSx} />;
@@ -98,8 +97,8 @@ export default function ContentEntry({ entryHandle }) {
     }
 
     const entry = (
-        <ListItem onContextMenu={(e) => e.preventDefault()} disablePadding dense sx={{ height: `${itemSize}px` }}>
-            <ListItemButton onClick={onClickHandler} sx={{ height: `${itemSize}px` }}>
+        <ListItem onContextMenu={(e) => e.preventDefault()} disablePadding dense>
+            <ListItemButton onClick={onClickHandler}>
                 <ListItemIcon sx={{ minWidth: `${iconSize + 5}px` }}>{icon}</ListItemIcon>
                 <ListItemText draggable={isDraggable} onDragStart={onDragHandler} primary={entryName} />
             </ListItemButton>


### PR DESCRIPTION
fix #104

Removed hardcoded content entry height

## tests

- content list
    - [x] When a file name is very long and contains multiple words connected with ` ` or `-`, the file name can be wrapped to multiple line, and the height of the item is adapting to the height of text.