### PR TITLE
Make paths to dynamically loaded resources relative. Fixes #121

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,17 +3,17 @@
     "description": "A browser-based IDE for CircuitPython supported microcontrollers. No installation needed. Handy and powerful.",
     "icons": [
         {
-            "src": "/blinka.svg",
+            "src": "blinka.svg",
             "type": "image/svg+xml",
             "sizes": "800x800"
         },
         {
-            "src": "/blinka-192.png",
+            "src": "blinka-192.png",
             "type": "image/png",
             "sizes": "192x192"
         },
         {
-            "src": "/blinka-512.png",
+            "src": "blinka-512.png",
             "type": "image/png",
             "sizes": "512x512"
         }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,8 +1,7 @@
-const CACHE_NAME = "CircuitPython-Online-IDE-cache";
-const OFFLINE_URL = "/index.html";
+const CACHE_NAME = "CircuitPython-Online-IDE-cache.20250715.001";
 
 // List all URLs you want to cache
-const urlsToCache = ["/", "/index.html"];
+const urlsToCache = ["index.html", "service-worker.js", "blinka-192.png", "blinka-512.png", "blinka.svg"];
 
 // Install event: Cache the static files
 self.addEventListener("install", (event) => {

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,17 @@
-const CACHE_NAME = "CircuitPython-Online-IDE-cache.20250715.001";
+// The service-worker is configured to allow the IDE to be installed
+// as a local app for offline use. In the Chrome URL bar you
+// will see an install button when you visit the IDE website.
+//
+// Once the app is installed, it will try to update itself when
+// the Internet is available.
+//
+// The intention is to cache all files needed to run the IDE.
+// If new files are added to the deployment, update the
+// CACHE_NAME variable to a new version and update the
+// values in urlsToCache to include the new files.
+
+// Name of the cache. Update when the list of files to cache changes.
+const CACHE_NAME = "CircuitPython-Online-IDE-cache.20250716.001";
 
 // List all URLs you want to cache
 const urlsToCache = ["index.html", "service-worker.js", "blinka-192.png", "blinka-512.png", "blinka.svg"];
@@ -27,6 +40,8 @@ self.addEventListener("activate", (event) => {
     );
 });
 
+// Intercept fetch requests, then try to get a fresh copy of the file
+// if the Internet is available, otherwise serve the cached version.
 self.addEventListener("fetch", (event) => {
     event.respondWith(
         caches.open(CACHE_NAME).then((cache) => {
@@ -39,6 +54,7 @@ self.addEventListener("fetch", (event) => {
                     })
                     .catch(() => {
                         // Network request failed; if there's a cache, serve it
+                        console.log("Serving cached response for " + event.request.url);
                         return cachedResponse;
                     });
 

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -2,7 +2,7 @@ export function register() {
     if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
             navigator.serviceWorker
-                .register("/service-worker.js")
+                .register("./service-worker.js")
                 .then((registration) => {
                     console.log("Service Worker registered:", registration);
                 })


### PR DESCRIPTION
Fixes #121

When running npm run dev locally, all paths in the project start at the root of the webserver. However, when hosting on github, the app is loaded under a project subdirectory. This causes some resource loads to fail which you can see in the console:

```
hook.js:608 Service Worker registration failed: TypeError: Failed to register a ServiceWorker for scope ('https://urfdvw.github.io/') with script ('https://urfdvw.github.io/service-worker.js'): A bad HTTP response code (404) was received when fetching the script.
```

So far I just found 'service-worker.js' and some of the icons failing to load. Since service-worker.js is just used to manage the caching API right now, I doubt users noticed the issue, it would just cause more network traffic.  