### PR TITLE
Modified icon imports to import them individually

### DIFF
--- a/src/components/RawConsole.jsx
+++ b/src/components/RawConsole.jsx
@@ -8,7 +8,8 @@ import * as constants from "../constants";
 // MUI
 import { Box, Button, IconButton, Typography, Tooltip } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import { ArrowDropDown, ArrowDropUp } from "@mui/icons-material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
+import ArrowDropUpIcon  from "@mui/icons-material/ArrowDropUp";
 
 const DARK_GREY = grey[300];
 // for scroll to the button
@@ -400,13 +401,13 @@ const RawConsole = () => {
                         <Tooltip title={"change send mode"} placement="top">
                             <IconButton>
                                 {modeHint ? (
-                                    <ArrowDropDown
+                                    <ArrowDropDownIcon
                                         onClick={() => {
                                             setModeHint(false);
                                         }}
                                     />
                                 ) : (
-                                    <ArrowDropUp
+                                    <ArrowDropUpIcon
                                         onClick={() => {
                                             setModeHint(true);
                                         }}

--- a/src/utilComponents/react-local-file-system/components/ContentEntry.jsx
+++ b/src/utilComponents/react-local-file-system/components/ContentEntry.jsx
@@ -2,11 +2,10 @@ import { useContext } from "react";
 
 import { ListItem, ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
 
-import {
-    DescriptionOutlined as FileIcon,
-    FolderOutlined as FolderIcon,
-    KeyboardReturnOutlined as ReturnIcon,
-} from "@mui/icons-material";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined"; //  FileIcon
+import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined"; // FolderIcon;
+import KeyboardReturnOutlineIcon from "@mui/icons-material/KeyboardReturnOutlined"; //ReturnIcon;
+
 import CurFolderContext from "../contexts/CurFolderContext";
 import DragContext from "../contexts/DragContext";
 import ApplyContextMenu from "./ApplyContextMenu";
@@ -24,11 +23,11 @@ export default function ContentEntry({ entryHandle }) {
     const iconSize = 20;
 
     const iconSx = { width: `${iconSize}px`, height: `${iconSize}px` };
-    let icon = <FileIcon sx={iconSx} />;
+    let icon = <DescriptionOutlinedIcon sx={iconSx} />;
     if (entryHandle.isParent) {
-        icon = <ReturnIcon sx={iconSx} />;
+        icon = <KeyboardReturnOutlineIcon sx={iconSx} />;
     } else if (isFolder(entryHandle)) {
-        icon = <FolderIcon sx={iconSx} />;
+        icon = <FolderOutlinedIcon sx={iconSx} />;
     }
     // handler
     const items = [

--- a/src/utilComponents/react-local-file-system/components/FolderView.jsx
+++ b/src/utilComponents/react-local-file-system/components/FolderView.jsx
@@ -6,18 +6,10 @@ import {
     Breadcrumbs,
     CircularProgress,
     Divider,
-    IconButton,
     List,
-    Toolbar,
-    Tooltip,
-    Typography,
 } from "@mui/material";
 
-import {
-    CreateNewFolderOutlined as NewFolderIcon,
-    NoteAddOutlined as NewFileIcon,
-    RefreshOutlined as RefreshIcon,
-} from "@mui/icons-material";
+
 import CurFolderContext from "../contexts/CurFolderContext";
 import DragContext from "../contexts/DragContext";
 import ContentEntry from "./ContentEntry";


### PR DESCRIPTION
This saves a time when starting up the app in dev mode, and probably cuts down on tree shaking when building for release.  

See #125