### PR TITLE
Added lazy loading to the plot component

### DIFF
--- a/src/components/RawPlotter.jsx
+++ b/src/components/RawPlotter.jsx
@@ -1,7 +1,7 @@
 // react
-import { useContext } from "react";
+import { useContext, lazy, Suspense } from "react";
 // plotly
-import Plot from "react-plotly.js";
+const Plot = lazy(() => import("react-plotly.js"));
 // context
 import AppContext from "../AppContext";
 
@@ -146,7 +146,9 @@ export default function RawPlotter({ node }) {
     return (
         <TabTemplate title="Plot" menuStructure={menuStructure}>
             {serialOutput && plot_data_lines.length > 0 ? (
-                <Plot data={data} layout={layout} />
+                <Suspense fallback={<div>Loading...</div>}>
+                    <Plot data={data} layout={layout} />
+                </Suspense>
             ) : (
                 <Typography style={{ padding: "20px" }}>No data to plot</Typography>
             )}


### PR DESCRIPTION
This change is intended to speed up loading the plotly library when running `npm run dev`.  I don't think it makes any difference in the load speed of the production app, but combined with #122, seems to speed up development time a lot when not using the service-manager cache.

When I put them both together, the page for `npm run dev` fully loads with a clean cache in about 12 seconds, vs. almost a minute.

Why go to all this trouble? As I noted in an earlier patch, I'm concerned about the caching in service-manager being too aggressive. 